### PR TITLE
Add FastAPI example

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import openai
+import os
+
+app = FastAPI()
+openai.api_key = os.environ["OPENAI_API_KEY"]
+
+class Prompt(BaseModel):
+    text: str
+
+@app.post("/generate-circuit")
+async def generate_circuit(prompt: Prompt):
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt.text}]
+    )
+    result = response["choices"][0]["message"]["content"]
+    return {"design": result}


### PR DESCRIPTION
## Summary
- create `main.py` for FastAPI usage with OpenAI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685feeb1c0948324989540a85149d6c1