### PR TITLE
Add KiCad integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FastAPI Circuit Generator
 
 This project exposes a small API built with [FastAPI](https://fastapi.tiangolo.com/) that uses the OpenAI API to generate circuit designs from text prompts.
+Additional endpoints allow you to create a KiCad project and a VS Code workspace from the generated design. If the `kicad-cli` tool is installed, the server will attempt to launch KiCad automatically.
 
 ## Installation
 
@@ -21,6 +22,13 @@ uvicorn main:app --reload
 The API will be available at `http://127.0.0.1:8000` by default.
 
 If the API key is not configured, the `/generate-circuit` endpoint will return an error message indicating that the key is missing.
+
+### KiCad integration
+
+Two additional endpoints provide basic integration with KiCad and Visual Studio Code:
+
+- `POST /generate-circuit-kicad` - Generates a circuit and saves it as a KiCad project. If the optional `kicad-cli` tool is installed, the schematic will be opened automatically.
+- `POST /generate-circuit-workspace` - Same as above but also creates a `.code-workspace` file for VS Code.
 
 Example `.env` file:
 

--- a/kicad_integration.py
+++ b/kicad_integration.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def save_design_to_project(design_text: str, project_dir: str) -> Path:
+    """Save design text to a KiCad project directory."""
+    os.makedirs(project_dir, exist_ok=True)
+    sch_path = Path(project_dir) / "design.kicad_sch"
+    with sch_path.open("w") as f:
+        f.write(design_text)
+    return sch_path
+
+
+def open_in_kicad(sch_path: str) -> bool:
+    """Attempt to open the schematic using the kicad-cli tool."""
+    try:
+        subprocess.run(["kicad-cli", "sch", "edit", sch_path], check=True)
+        return True
+    except FileNotFoundError:
+        return False
+    except subprocess.CalledProcessError:
+        return False

--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 import openai
 import os
+from uuid import uuid4
+
+from kicad_integration import save_design_to_project, open_in_kicad
+from vscode_workspace import create_workspace
 
 load_dotenv()
 
@@ -29,3 +33,38 @@ async def generate_circuit(prompt: Prompt):
     )
     result = response["choices"][0]["message"]["content"]
     return {"design": result}
+
+
+@app.post("/generate-circuit-kicad")
+async def generate_circuit_kicad(prompt: Prompt):
+    """Generate a circuit and attempt to open it with KiCad."""
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt.text}],
+    )
+    design = response["choices"][0]["message"]["content"]
+    project_dir = f"project_{uuid4().hex}"
+    sch_path = save_design_to_project(design, project_dir)
+    opened = open_in_kicad(str(sch_path))
+    return {"design": design, "kicad_project": project_dir, "opened_in_kicad": opened}
+
+
+@app.post("/generate-circuit-workspace")
+async def generate_circuit_workspace(prompt: Prompt):
+    """Generate a circuit and create a VS Code workspace."""
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt.text}],
+    )
+    design = response["choices"][0]["message"]["content"]
+    project_dir = f"project_{uuid4().hex}"
+    sch_path = save_design_to_project(design, project_dir)
+    workspace = f"{project_dir}.code-workspace"
+    create_workspace(project_dir, workspace)
+    opened = open_in_kicad(str(sch_path))
+    return {
+        "design": design,
+        "workspace": workspace,
+        "kicad_project": project_dir,
+        "opened_in_kicad": opened,
+    }

--- a/vscode_workspace.py
+++ b/vscode_workspace.py
@@ -1,0 +1,11 @@
+import json
+from pathlib import Path
+
+
+def create_workspace(project_dir: str, workspace_path: str) -> None:
+    """Create a Visual Studio Code workspace referencing the project."""
+    ws = {
+        "folders": [{"path": project_dir}],
+        "settings": {"kicad.projectPath": project_dir},
+    }
+    Path(workspace_path).write_text(json.dumps(ws, indent=2))


### PR DESCRIPTION
## Summary
- add basic KiCad and VS Code workspace helpers
- create endpoints for generating KiCad projects and VS Code workspaces
- mention the new features in the README

## Testing
- `python -m py_compile main.py kicad_integration.py vscode_workspace.py`

------
https://chatgpt.com/codex/tasks/task_e_68626e3ca330832496313a8e8f5b5cc0